### PR TITLE
[Rogo Build] Added Rogo build support via Build.rogue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.rogo
+CMakeCache.txt
+CMakeFiles
+Makefile
+antsy
+cmake_install.cmake
+libtmt
+*.swp
+*.swo

--- a/Build.rogue
+++ b/Build.rogue
@@ -1,0 +1,267 @@
+# To run this build file, install Rogue from github.com/AbePralle/Rogue and type "rogo" at the command line.
+
+# Rogo is a "build your own build system" facilitator. At its core Rogo just recompiles build files if
+# needed and then runs the build executable while forwarding any command line arguments. This file contains
+# a default framework which uses introspection to turn command line arguments into parameterized routine calls.
+
+# Example: to handle the command "rogo abc xyz 5", define "routine rogo_abc_xyz( n:Int32 )".
+
+# "rogo_default" will run in the absence of any other command line argument.
+
+#$ LIBRARIES(Linux) = libsdl1.2-dev(sdl)
+#$ LIBRARIES(macOS) = sdl
+#$ LIBRARIES = cmake
+
+# description()s are optional - Rogo uses introspection to determine which commands are available.
+# 'rogo help default' displays the description for "default", etc.
+description( "default", "The default action is performed when no other actions are specified. Use 'rogo default' to explicitly perform the default option." )
+description( "help",    "Displays a list of all actions that can be performed by Rogo." )
+
+routine rogo_default
+  if (not File.exists("libtmt"))
+    execute @|git clone https://github.com/MurphyMc/libtmt
+  endIf
+
+  if (File.exists("CMakeCache.txt"))
+    # See if CMake is cached to a different folder (easily happens when using Parallels)
+    contingent
+      local cmake_cachefile_dir = File.load_as_string( "CMakeCache.txt" ).split( '\n' ).find( $.contains("CMAKE_CACHEFILE_DIR") )
+      necessary (cmake_cachefile_dir.exists)
+      local cmake_path = cmake_cachefile_dir.value.after_first( "INTERNAL=" )
+      local cwd  = Process.run( "pwd", &inherit_environment )->String.trimmed
+      necessary (cmake_path == cwd)
+    unsatisfied
+      rogo_clean
+    endContingent
+  endIf
+
+  if (not File.exists("CMakeCache.txt"))
+    execute @|cmake .
+  endIf
+
+  execute( "cmake --build ." )
+endRoutine
+
+routine rogo_clean
+  # Delete all CMake-generated files
+  println "Deleting CMake cache"
+  File.delete( "CMakeCache.txt" )
+  File.delete( "CMakeFiles/" )
+  File.delete( "Makefile" )
+  File.delete( "cmake_install.cmake" )
+
+  File.delete( "antsy" )
+endRoutine
+
+routine execute( commands:String, &suppress_error )->Logical
+  forEach (cmd in LineReader(commands))
+    print( "> " ).println( cmd )
+    if (System.run(cmd) != 0)
+      if (suppress_error) return false
+      else                throw Error( "Build failed." )
+    endIf
+  endForEach
+  return true
+endRoutine
+
+#------------------------------------------------------------------------------
+# Introspection-based Launcher Framework
+#------------------------------------------------------------------------------
+routine syntax( command:String, text:String )
+  Build.rogo_syntax[ command ] = text
+endRoutine
+
+routine description( command:String, text:String )
+  Build.rogo_descriptions[ command ] = text
+endRoutine
+
+routine help( command:String, description=null:String, syntax=null:String )
+  if (description) Global.description( command, description )
+  if (syntax)      Global.syntax( command, syntax )
+endRoutine
+
+try
+  Build.launch
+catch (err:Error)
+  Build.rogo_error = err
+  Build.on_error
+endTry
+
+class Build [singleton]
+  PROPERTIES
+    rogo_syntax         = StringTable<<String>>()
+    rogo_descriptions   = StringTable<<String>>()
+    rogo_prefix         = ?:{ $moduleName.count:$moduleName "::" || "" } + "rogo_" : String
+    rogo_command        = "default"
+    rogo_args           = @[]
+    rogo_error          : Error
+
+    LOCAL_DEFS_FILE     = "Local.mk"
+
+  METHODS
+    method launch
+      rogo_args.add( forEach in System.command_line_arguments )
+      read_defs
+      on_launch
+      parse_args
+      dispatch_command
+
+    method dispatch_command
+      local m = find_command( rogo_command )
+      require m
+
+      local args = @[]
+      forEach (arg in rogo_args)
+        which (arg)
+          case "true":  args.add( true )
+          case "false": args.add( false )
+          case "null":  args.add( NullValue )
+          others:       args.add( arg )
+        endWhich
+      endForEach
+      if (m.parameter_count == 1 and args.count > 1) args = @[ args ] # Wrap args in a ValueList.
+      m.call( Global, args )
+
+    method find_command( name:String )->MethodInfo
+      return <<Global>>.find_method( rogo_prefix + name )
+
+    method on_error
+      Console.error.println rogo_error
+      on_exit
+      System.exit 1
+
+    method on_command_found
+      noAction
+
+    method on_command_not_found
+      println "=" * 79
+      println "ERROR: No such command '$'." (rogo_args.first)
+      println "=" * 79
+      println
+      rogo_command = "help"
+      rogo_args.clear
+      on_command_found
+
+    method on_launch
+      noAction
+
+    method on_exit
+      noAction
+
+    method parse_args
+      block
+        if (rogo_args.count)
+          local parts = String[]
+          parts.add( forEach in rogo_args )
+          rogo_args.clear
+
+          while (parts.count)
+            local cmd = _join( parts )
+            if (find_command(cmd))
+              rogo_command = cmd
+              on_command_found
+              escapeBlock
+            endIf
+            rogo_args.insert( parts.remove_last )
+          endWhile
+
+          on_command_not_found
+        endIf
+
+        # Use default command
+        on_command_found
+      endBlock
+
+    method read_defs
+      read_defs( LOCAL_DEFS_FILE )
+
+    method read_defs( defs_filepath:String )
+      # Attempt to read defs from Local.mk
+      local overrides = String[]
+      if (File.exists(defs_filepath))
+        forEach (line in LineReader(File(defs_filepath)))
+          if (line.contains("="))
+            local name  = line.before_first('=').trimmed
+            local value = line.after_first('=').trimmed
+            if (value.begins_with('"') or value.begins_with('\''))
+              value = value.leftmost(-1).rightmost(-1)
+            endIf
+            local p = <<Build>>.find_property( name )
+            if (p)
+              overrides.add( "$ = $" (name,value) )
+              <<Build>>.set_property( this, p, Value(value) )
+            endIf
+          endIf
+        endForEach
+      endIf
+
+    method _join( value:Value )->String
+      local args = String[]
+      args.add( forEach in value )
+      return args.join( "_" )
+endClass
+
+
+routine rogo_help( command="":String )
+  command = Build._join( Build.rogo_args )
+  if (command.count)
+    local syntax = get_syntax( command )
+    local success = false
+    if (syntax)
+      println "SYNTAX"
+      println "  " + syntax
+      println
+      success = true
+    endIf
+    local description = get_description( command )
+    if (description)
+      println "DESCRIPTION"
+      forEach (line in LineReader(description.word_wrapped(76)))
+        print( "  " ).println( line )
+      endForEach
+      println
+      success = true
+    endIf
+    if (success)
+      return
+    else
+      println "=" * 79
+      println "ERROR: No such command '$'." (command)
+      println "=" * 79
+      println
+    endIf
+  endIf
+
+  println "USAGE"
+  local lines = String[]
+  forEach (m in <<Global>>.methods)
+    if (m.name.begins_with(Build.rogo_prefix))
+      lines.add( "  " + get_syntax(m.name.after_first(Build.rogo_prefix)) )
+    endIf
+  endForEach
+  lines.sort( (a,b)=>(a<b) )
+  println (forEach in lines)
+  println
+endRoutine
+
+
+routine get_syntax( m_name:String )->String
+  if (Build.rogo_syntax.contains(m_name))
+    return "rogo " + Build.rogo_syntax[ m_name ]
+  else
+    local m = <<Global>>.find_method( Build.rogo_prefix + m_name )
+    if (not m) return null
+    local line = "rogo $" (m_name.replacing('_',' '))
+    line += " <$>" (m.parameter_name(forEach in 0..<m.parameter_count))
+    return line
+  endIf
+endRoutine
+
+
+routine get_description( m_name:String )->String
+  if (Build.rogo_descriptions.contains(m_name))
+    return Build.rogo_descriptions[ m_name ]
+  else
+    return null
+  endIf
+endRoutine

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,4 +32,4 @@ add_executable(antsy
 find_package(SDL REQUIRED)
 include_directories(${SDL_INCLUDE_DIR})
 
-target_link_libraries(antsy SDL)
+target_link_libraries(antsy ${SDL_LIBRARY})

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ to do the rendering, input, etc.
 
 ## Compiling
 
+### Rogo
+
+To compile Antsy using the Rogo build system, install Rogue 1.5.1 or better from here:
+
+[https://github.com/AbePralle/Rogue](https://github.com/AbePralle/Rogue)
+
+and then execute the following to build antsy on Ubunto or macOS (antsy currently compiles but does not render correctly on macOS):
+
+    rogo
+
+### CMake
+
 You need SDL 1.2.  On Ubuntu, `apt install libsdl1.2-dev` should do it.
 
 You need cmake.  On Ubuntu, `apt install cmake` should do it.
@@ -20,9 +32,6 @@ You need libtmt.  `git clone https://github.com/MurphyMc/libtmt` should
 do it.
 
 You should then be able to build with `cmake --build .`.
-
-If you want xterm window title setting, you'll need to enable
-`ANSTY_TITLE_SET`.
 
 ## Commandline options
 

--- a/antsy.c
+++ b/antsy.c
@@ -1,5 +1,5 @@
 #define _GNU_SOURCE
-#include <SDL/SDL.h>
+#include "SDL.h"
 #include <sys/time.h>
 #include <unistd.h>
 #include <stdio.h>
@@ -138,6 +138,8 @@ static void handle_sdl_keypress (SDL_KeyboardEvent * event)
       {
         key = TMT_KEY_BACK_TAB;
       }
+      break;
+    default:
       break;
   }
   char ch[2] = {0};
@@ -530,7 +532,7 @@ static inline void draw_cell (size_t x, size_t y, TMTCHAR * c)
     // Draw blink as bright background
     // Maybe should do real blink?
     bg += 8;
-    if (fg == bg & !c->a.invisible) fg -= 8;
+    if (fg == bg && !c->a.invisible) fg -= 8;
   }
   if (c->a.reverse)
   {
@@ -670,5 +672,7 @@ void terminal_callback (tmt_msg_t m, TMT *vt, const void *a, void *p)
       break;
     }
 #endif
+    default:
+      break;
   }
 }


### PR DESCRIPTION
- Details in update README.md.
- Rogo still uses CMake underneath.
- Removed info about ANTSY_TITLE_SET since this is already working correctly in CMake build.
- Also fixed build errors and warnings for macOS.
- antsy compiles for macOS but does not render (blank window).